### PR TITLE
fix: add VMware connection validation and improve error handling

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -1,11 +1,21 @@
-vcenter_host: "192.168.0.254" #  vCenter IP address or hostname
-vcenter_user: "administrator@deal.local" # Username for the vCenter user
-vcenter_password: "s3cr3t" # Password for the vCenter user
-datacenter: "Datacenter1"        # Datacenter name
-cluster: ""              # Cluster name (leave empty for standalone ESXi)
-datastore: "N4T0"          # Default datastore name
-network: "VM Network"            # Default network name
-insecure: true                  # Skip SSL certificate verification
-api_key: "s3cr3t-api-key"        # API key for authentication
-log_file: "./logs/vmware_mcp.log"  # Log file path
-log_level: "DEBUG"                # Log level: DEBUG/INFO/WARNING/ERROR
+# VMware MCP Server Configuration Sample
+
+# Required VMware connection settings
+vcenter_host: "192.168.0.254" # vCenter or ESXi IP address or hostname
+vcenter_user: "administrator@deal.local" # Username for vCenter/ESXi
+vcenter_password: "s3cr3t" # Password for vCenter/ESXi
+
+# Optional VMware settings
+# (Uncomment and set as needed)
+# datacenter: "Datacenter1"        # Datacenter name
+# cluster: ""                      # Cluster name (leave empty for standalone ESXi)
+# datastore: "N4T0"                # Default datastore name
+# network: "VM Network"            # Default network name
+# insecure: true                    # Skip SSL certificate verification (true/false)
+
+# MCP Server settings
+# api_key: ""                      # (Optional) Set to require an API key for all tool calls; leave blank to disable API key authentication
+# log_file: "./logs/vmware_mcp.log"  # Log file path
+# log_level: "DEBUG"                # Log level: DEBUG/INFO/WARNING/ERROR
+# host: "0.0.0.0"                   # Server bind address
+# port: 8000                         # Server port

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,15 @@ class VMwareConfig:
     datastore: Optional[str] = None
     network: Optional[str] = None
     insecure: bool = False
+    
+    def __post_init__(self):
+        """Validate required fields."""
+        if not self.host:
+            raise ValueError("VCENTER_HOST is required")
+        if not self.user:
+            raise ValueError("VCENTER_USER is required")
+        if not self.password:
+            raise ValueError("VCENTER_PASSWORD is required")
 
 
 @dataclass

--- a/src/vmware.py
+++ b/src/vmware.py
@@ -51,6 +51,14 @@ class VMwareManager:
     def _connect(self) -> None:
         """Connect to vCenter/ESXi using the official VMware SDK."""
         try:
+            # Validate connection parameters
+            if not self.config.host:
+                raise VMwareConnectionError("VCENTER_HOST is required")
+            if not self.config.user:
+                raise VMwareConnectionError("VCENTER_USER is required")
+            if not self.config.password:
+                raise VMwareConnectionError("VCENTER_PASSWORD is required")
+            
             # Create session with SSL verification settings
             session = requests.session()
             if self.config.insecure:
@@ -65,7 +73,7 @@ class VMwareManager:
                 session=session
             )
             
-            logging.info("Successfully connected to VMware vCenter/ESXi API")
+            logging.info(f"Successfully connected to VMware vCenter/ESXi API at {self.config.host}")
             
         except Exception as e:
             logging.error(f"Failed to connect to vCenter/ESXi: {e}")


### PR DESCRIPTION
- Add validation in VMwareConfig to ensure required fields are not None
- Improve error handling in VMwareManager with specific parameter validation
- Add comprehensive troubleshooting section for connection errors
- Provide clear examples for Docker Compose and Docker run configurations
- Fix 'can only concatenate str (not NoneType) to str' error
- Add better error messages for missing VCENTER_HOST, VCENTER_USER, VCENTER_PASSWORD