### PR TITLE
fix: resolve async context manager error in MCP server startup

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -54,7 +54,13 @@ async def main() -> None:
         
         # Run the server using stdio transport
         from mcp.server.stdio import stdio_server
-        await stdio_server(server)
+        try:
+            # Try the context manager approach first
+            async with stdio_server(server) as stdio:
+                await stdio.run()
+        except TypeError:
+            # Fallback to direct await if context manager doesn't work
+            await stdio_server(server)
         
     except Exception as e:
         logging.error(f"Failed to start server: {e}")


### PR DESCRIPTION
- Fix 'object _AsyncGeneratorContextManager can't be used in await expression' error
- Add fallback handling for different MCP stdio_server implementations
- Try context manager approach first, fallback to direct await if needed
- This resolves the Goose extension startup failure